### PR TITLE
Update Modulefile dependency information

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'puppetlabs-mrepo'
-version '0.1.2'
+version '0.1.3'
 source 'git://github.com/puppetlabs/puppetlabs-mrepo'
 author 'puppetlabs'
 license 'Apache 2.0'


### PR DESCRIPTION
The dependency field in the Modulefile was missing a comma, causing incorrect metadata to be generated. Fixed this.
