### PR TITLE
(#16645) Adjust apache dependency

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -8,7 +8,7 @@ description 'Puppet module to configure and manage mrepo mirrors. Mirrors can
 be generated from distribution ISOs, existing RPM mirrors, the Redhat Network,
 or Yast Online Update.'
 
-dependency 'puppetlabs-apache', '>= 0.0.3'
+dependency 'puppetlabs/apache', '>= 0.0.3'
 dependency 'puppetlabs/vcsrepo', '>= 0.0.3'
 dependency 'puppetlabs/stdlib', '>= 0.1.6'
 dependency 'nanliu/staging', '>= 0.1.0'


### PR DESCRIPTION
Prior to this commit, the dependency on puppetlabs-apache was
expressed with a hyphen instead of a forward slash.

This commit corrects the Modulefile and allows the module tool to
consume the mrepo module. Obviously a better fix is to make the
module tool more tolerant but this is a useful short-term fix.
