### PR TITLE
No guarantee that 'mrepo::repos' will be included

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@
 # repo_hash = undef (Default)
 # Hash with repo definitions to create
 # These can also be provided via Hiera
-# 
+#
 # Other optional parameters can be found in the mrepo::params class
 #
 # == Examples
@@ -43,15 +43,13 @@ class mrepo {
   Class['mrepo::package']    -> Class['mrepo::rhn']
   Class['mrepo::package']    -> Class['mrepo::selinux']
   Class['mrepo::webservice'] -> Class['mrepo::selinux']
-  Class['mrepo::selinux']    -> Class['mrepo::repos']
 
   anchor { 'mrepo::end':
     require => [
-#      Class['mrepo::package'],
-#      Class['mrepo::webservice'],
-#      Class['mrepo::selinux'],
-#      Class['mrepo::rhn'],
-      Class['mrepo::repos'],
+      Class['mrepo::package'],
+      Class['mrepo::webservice'],
+      Class['mrepo::selinux'],
+      Class['mrepo::rhn'],
     ],
   }
 }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -3,4 +3,8 @@ class mrepo::repos (
 ) {
   validate_hash( $resources )
   create_resources('mrepo::repo',$resources)
+
+  Class['mrepo::selinux'] ->
+  Class['mrepo::repos'] ->
+  Anchor['mrepo::end']
 }


### PR DESCRIPTION
Breaking dependencies on it that exist at the top-level class, and
trying to implement the anchor pattern a bit differently.

Fixes #13
