### PR TITLE
Include mrepo::repos on init

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,6 +33,7 @@ class mrepo {
   include mrepo::rhn
   include mrepo::webservice
   include mrepo::selinux
+  include mrepo::repos
 
   anchor { 'mrepo::begin':
     before => Class['mrepo::package'],


### PR DESCRIPTION
There's a problem with the latests commits:

```
Error: Could not find resource 'Class[Mrepo::Repos]' for relationship from 'Class[Mrepo::Selinux]' on node intelie-mirror
Error: Could not find resource 'Class[Mrepo::Repos]' for relationship from 'Class[Mrepo::Selinux]' on node intelie-mirror
```
