### PR TITLE
mrepo: absent case should use mrepo_munge'd name

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -280,7 +280,7 @@ define mrepo::repo (
           force   => true,
           before  => File[$src_root_subdir],
           require => Exec["Unmount any mirrored ISOs for ${name}"];
-        "${mrepo::params::src_root}/${name}":
+        $src_root_subdir:
           ensure  => absent,
           backup  => false,
           recurse => false,


### PR DESCRIPTION
Needed otherwise it's possible to get invalid relationship error:

```
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: 
Invalid relationship: 
File[/my/mrepo/wwwdir/ceph-infernalis-x86_64]
{ before => 
File[/my/mrepo/srcdir/ceph-infernalis-x86_64]}, 
because 
File[/my/mrepo/srcdir/ceph-infernalis-x86_64] 
doesn't seem to be in the catalog
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```
