### PR TITLE
Add `mailfrom` and `smtpserver` parameters

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -65,8 +65,13 @@
 # Default: /usr/bin/gensystemid 
 #
 # [*mailto*]
+# The email recipient for mrepo updates. Defaults to unset, meaning no email will be sent.
 #
-# The email recipient for mrepo updates. Defaults to unset
+# [*mailfrom*]
+# The email sender for mrepo updates. Defaults to unset, meaning mrepo will use its default of `mrepo@`_fqdn_.
+#
+# [*smtpserver*]
+# The SMTP server to use for sending update emails.  Defaults to unset, meaning mrepo will use its default of `localhost`.
 #
 # == Examples
 #
@@ -107,6 +112,8 @@ class mrepo::params (
   $rhn_password   = '',
   $genid_command  = '/usr/bin/gensystemid',
   $mailto         = 'UNSET',
+  $mailfrom       = 'UNSET',
+  $smtpserver     = 'UNSET',
   $git_proto      = 'git',
   $descriptions   = {},
   $http_proxy     = '',
@@ -120,6 +127,17 @@ class mrepo::params (
   validate_re($port, '^\d+$')
   validate_bool($rhn)
   validate_hash($descriptions)
+
+  # validate email addresses based on regex found in `is_email_address`
+  # in newer stdlib versions.  If metadata.json updated to require
+  # *4.12.0* or newer, the `validate_re` calls can be replaced by
+  # `validate_email_address`.
+  if $mailto != 'UNSET' {
+    validate_re($mailto, '\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z$', "${mailto} is not a valid email address")
+  }
+  if $mailfrom != 'UNSET' {
+    validate_re($mailfrom, '\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z$', "${mailfrom} is not a valid email address")
+  }
 
   if $rhn {
     validate_re($rhn_username, '.+')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -128,10 +128,10 @@ class mrepo::params (
   validate_bool($rhn)
   validate_hash($descriptions)
 
-  if $mailto != undef {
+  if $mailto {
     validate_email_address($mailto)
   }
-  if $mailfrom != undef {
+  if $mailfrom {
     validate_email_address($mailfrom)
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -111,9 +111,9 @@ class mrepo::params (
   $rhn_username   = '',
   $rhn_password   = '',
   $genid_command  = '/usr/bin/gensystemid',
-  $mailto         = 'UNSET',
-  $mailfrom       = 'UNSET',
-  $smtpserver     = 'UNSET',
+  $mailto         = undef,
+  $mailfrom       = undef,
+  $smtpserver     = undef,
   $git_proto      = 'git',
   $descriptions   = {},
   $http_proxy     = '',
@@ -128,15 +128,11 @@ class mrepo::params (
   validate_bool($rhn)
   validate_hash($descriptions)
 
-  # validate email addresses based on regex found in `is_email_address`
-  # in newer stdlib versions.  If metadata.json updated to require
-  # *4.12.0* or newer, the `validate_re` calls can be replaced by
-  # `validate_email_address`.
-  if $mailto != 'UNSET' {
-    validate_re($mailto, '\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z$', "${mailto} is not a valid email address")
+  if $mailto != undef {
+    validate_email_address($mailto)
   }
-  if $mailfrom != 'UNSET' {
-    validate_re($mailfrom, '\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z]+)*\.[a-z]+\z$', "${mailfrom} is not a valid email address")
+  if $mailfrom != undef {
+    validate_email_address($mailfrom)
   }
 
   if $rhn {

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
   "dependencies": [
     {"name":"puppetlabs/apache","version_requirement":">= 0.6.0 < 2.0.0"},
     {"name":"puppetlabs/vcsrepo","version_requirement":">= 0.0.3 < 2.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 0.1.6 < 5.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.12.0 < 5.0.0"},
     {"name":"nanliu/staging","version_requirement":">= 0.1.0 < 2.0.0"}
   ]
 }

--- a/templates/mrepo.conf.erb
+++ b/templates/mrepo.conf.erb
@@ -20,4 +20,10 @@ rhnlogin = <%= @rhn_username %>
 
 <% unless (mailto = @mailto) == 'UNSET' -%>
 mailto = <%= mailto %>
+<%   if (mailfrom = @mailfrom) != 'UNSET' -%>
+mailfrom = <%= mailfrom %>
+<%   end -%>
+<%   if (smtpserver = @smtpserver) != 'UNSET' -%>
+smtp-server = <%= smtpserver %>
+<%   end -%>
 <% end -%>

--- a/templates/mrepo.conf.erb
+++ b/templates/mrepo.conf.erb
@@ -18,12 +18,12 @@ rhnlogin = <%= @rhn_username %>:<%= @rhn_password %>
 rhnlogin = <%= @rhn_username %>
 <% end -%>
 
-<% unless (mailto = @mailto) == 'UNSET' -%>
-mailto = <%= mailto %>
-<%   if (mailfrom = @mailfrom) != 'UNSET' -%>
-mailfrom = <%= mailfrom %>
+<% if @mailto -%>
+mailto = <%= @mailto %>
+<%   if @mailfrom -%>
+mailfrom = <%= @mailfrom %>
 <%   end -%>
-<%   if (smtpserver = @smtpserver) != 'UNSET' -%>
-smtp-server = <%= smtpserver %>
+<%   if @smtpserver -%>
+smtp-server = <%= @smtpserver %>
 <%   end -%>
 <% end -%>


### PR DESCRIPTION
(MODULES-3860) Add `mailfrom` and `smtpserver` parameters representing
the mrepo `mailfrom` and `smtp-server` configuration settings.