### PR TITLE
Refactor to use the params pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install and configure a basic mrepo installation
 
 Override default values and enable redhat network support for use in other classes
 
-    class { 'mrepo::params':
+    class { 'mrepo':
       selinux       => true,
       rhn           => true,
       rhn_username  => 'user',
@@ -29,10 +29,10 @@ Or using Hiera for parameters (same example)
     class { 'mrepo': }
 
   Hiera:
-    mrepo::params::selinux: true
-    mrepo::params::rhn: true
-    mrepo::params::rhn_username: user
-    mrepo::params::rhn_password: pass
+    mrepo::selinux: true
+    mrepo::rhn: true
+    mrepo::rhn_username: user
+    mrepo::rhn_password: pass
 
 Mirror multiple centos 5 repositories
 
@@ -86,7 +86,7 @@ Mirror multiple rhel channels
 
 ## Usage ##
 
-If you need to customize the mrepo default settings, include the mrepo::params
+If you need to customize the mrepo default settings, include the mrepo
 class and include the appropriate variables. Else, you should be able to use
 the mrepo::repo by itself to instantiate repositories.
 
@@ -161,6 +161,39 @@ For full details on how mrepo is used, see [the mrepo usage
 page](https://github.com/dagwieers/mrepo/blob/master/docs/usage.txt).
 
 ## Caveats ##
+
+### Params Pattern ###
+
+This module was previously using a pattern
+
+It now follows the params pattern, where parameters are set in the params
+class as default, inherited, then overwritten as needed when calling the base class.
+
+#### Before:
+
+Using classes
+
+```puppet
+class { '::mrepo::params':
+  selinux       => true,
+  rhn           => true,
+  rhn_username  => 'user',
+  rhn_password  => 'pass',
+}
+```
+
+
+After:
+
+```puppet
+class { '::mrepo':
+  selinux       => true,
+  rhn           => true,
+  rhn_username  => 'user',
+  rhn_password  => 'pass',
+}
+```
+
 
 ### SELinux ###
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ page](https://github.com/dagwieers/mrepo/blob/master/docs/usage.txt).
 
 ### Params Pattern ###
 
-This module was previously using a pattern
+This module was previously using a design where the params class was used as the main class and included in other classes.
 
 It now follows the params pattern, where parameters are set in the params
 class as default, inherited, then overwritten as needed when calling the base class.
@@ -182,8 +182,7 @@ class { '::mrepo::params':
 }
 ```
 
-
-After:
+#### After:
 
 ```puppet
 class { '::mrepo':

--- a/examples/rhn.pp
+++ b/examples/rhn.pp
@@ -1,7 +1,5 @@
-class { '::mrepo::params':
+class { '::mrepo':
   rhn          => true,
   rhn_username => 'test',
   rhn_password => 'test',
 }
-
-include ::mrepo::rhn

--- a/examples/selinux.pp
+++ b/examples/selinux.pp
@@ -1,4 +1,3 @@
-class { '::mrepo::params':
+class { '::mrepo':
   selinux => true,
 }
-include ::mrepo::selinux

--- a/manifests/exports.pp
+++ b/manifests/exports.pp
@@ -15,7 +15,6 @@
 # Copyright 2012 Puppet Labs, unless otherwise noted
 #
 class mrepo::exports($clients) {
-  include ::mrepo::params
 
   $file_path = '/usr/local/sbin/export-mrepo'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,14 +5,101 @@
 # outside of puppet and only want dependencies to be installed, then include
 # this class.
 #
+# Parameters:
+# [*src_root*]
+# The path to store the mrepo mirror data.
+# Default: /var/mrepo
 #
-# == Parameters
+# [*www_root*]
+# The path of the mrepo html document root.
+# Default: /var/www/mrepo
 #
-# repo_hash = undef (Default)
-# Hash with repo definitions to create
-# These can also be provided via Hiera
+# [*www_ip*]
+# Which IP address to use when www_ip_based is set.
+# Default: $::ipaddress
 #
-# Other optional parameters can be found in the mrepo::params class
+# [*www_ip_based*]
+# Whether to use IP-based virtual hosts or not.
+# Default: false
+#
+# [*user*]
+# The account to use for mirroring the files.
+# Default: apache
+#
+# [*group*]
+# The group to use for mirroring the files.
+# Default: apache
+#
+# [*source*]
+# The package source.
+# Default: package
+# Values: git, package
+#
+# [*ensure_src*]
+# Ensure value for the package source.
+# Note that with source set to 'git', setting ensure_src to 'latest'
+#  may cause module-removed source files (e.g. httpd mrepo.conf) to be restored
+# Default: latest
+# Values: latest, present, absent
+#
+# [*selinux*]
+# Whether to update the selinux context for the mrepo document root.
+# Default: the selinux fact.
+# Values: true, false
+#
+# [*rhn*]
+# Whether to install RedHat dependencies or not. Defaults to false.
+# Default: false
+# Values: true, false
+#
+# [*rhn_config*]
+# Whether to install RedHat dependencies for RHN on RHEL. Defaults to false.
+# Note: Irrelevant (assumed true) for CentOS servers with rhn=true.
+# Default: false
+# Values: true, false
+#
+# [*rhn_username*]
+# The Redhat Network username. Must be set if the param rhn is true.
+#
+# [*rhn_password*]
+# The Redhat Network password. Must be set if the param rhn is true.
+#
+# [*rhnget_cleanup*]
+# Clean up packages that are not on the sending side?
+# Default: undef
+# Values: undef, true, false
+#
+# [*rhnget_download_all*]
+# Download older versions of packages?
+# Default: undef
+# Values: undef, true, false
+#
+# [*genid_command*]
+# The base command to use to generate a systemid for RHN (mrepo::repo::rhn).
+# Default: /usr/bin/gensystemid
+#
+# [*mailto*]
+# The email recipient for mrepo updates. Defaults to unset, meaning no email will be sent.
+#
+# [*mailfrom*]
+# The email sender for mrepo updates. Defaults to unset, meaning mrepo will use its default of `mrepo@`_fqdn_.
+#
+# [*smtpserver*]
+# The SMTP server to use for sending update emails.  Defaults to unset, meaning mrepo will use its default of `localhost`.
+#
+# == Examples
+#
+# node default {
+#   class { "mrepo":
+#     src_root     => '/srv/mrepo',
+#     www_root     => '/srv/www/mrepo',
+#     user         => 'www-user',
+#     source       => 'package',
+#     rhn          => true,
+#     rhn_username => 'user',
+#     rhn_password => 'pass',
+#   }
+# }
 #
 # == Examples
 #
@@ -28,29 +115,92 @@
 #
 # Copyright 2011 Puppet Labs, unless otherwise noted
 #
-class mrepo {
+class mrepo (
+  $src_root             = $::mrepo::params::src_root,
+  $www_root             = $::mrepo::params::www_root,
+  $www_servername       = $::mrepo::params::www_servername,
+  $www_ip               = $::mrepo::params::www_ip,
+  $www_ip_based         = $::mrepo::params::www_ip_based,
+  $user                 = $::mrepo::params::user,
+  $group                = $::mrepo::params::group,
+  $source               = $::mrepo::params::source,
+  $ensure_src           = $::mrepo::params::ensure_src,
+  $selinux              = $::mrepo::params::selinux,
+  $rhn                  = $::mrepo::params::rhn,
+  $rhn_config           = $::mrepo::params::rhn_config,
+  $rhn_username         = $::mrepo::params::rhn_username,
+  $rhn_password         = $::mrepo::params::rhn_password,
+  $rhnget_cleanup       = $::mrepo::params::rhnget_cleanup,
+  $rhnget_download_all  = $::mrepo::params::rhnget_download_all,
+  $genid_command        = $::mrepo::params::genid_command,
+  $mailto               = $::mrepo::params::mailto,
+  $mailfrom             = $::mrepo::params::mailfrom,
+  $smtpserver           = $::mrepo::params::smtpserver,
+  $git_proto            = $::mrepo::params::git_proto,
+  $descriptions         = $::mrepo::params::descriptions,
+  $http_proxy           = $::mrepo::params::http_proxy,
+  $https_proxy          = $::mrepo::params::https_proxy,
+  $priority             = $::mrepo::params::priority,
+  $port                 = $::mrepo::params::port,
+  $selinux_context      = $::mrepo::params::selinux_context,
+) inherits ::mrepo::params {
+
+  validate_re($source, '^git$|^package$')
+  validate_re($git_proto, '^git$|^https$')
+  validate_re($priority, '^\d+$')
+  validate_re($port, '^\d+$')
+  validate_bool($rhn)
+  validate_hash($descriptions)
+
+  assert_private('You can no longer refer to the mrepo::params class directly, see https://github.com/voxpupuli/puppet-mrepo#caveats for more details')
+
+  if $mailto {
+    validate_email_address($mailto)
+  }
+  if $mailfrom {
+    validate_email_address($mailfrom)
+  }
+
+  if $rhn {
+    validate_re($rhn_username, '.+')
+    validate_re($rhn_password, '.+')
+  }
+
+  if $rhnget_cleanup != undef {
+    validate_bool($rhnget_cleanup)
+  }
+  if $rhnget_download_all != undef {
+    validate_bool($rhnget_download_all)
+  }
+
+  # Validate selinux usage. If manually set, validate as a bool and use that value.
+  # If undefined and selinux is present and not disabled, use selinux.
+  case $mrepo::selinux {
+    undef: {
+      case $::selinux {
+        'enforcing', 'permissive': {
+          $use_selinux = true
+        }
+        'disabled', default: {
+          $use_selinux = false
+        }
+      }
+    }
+    default: {
+      validate_bool($selinux)
+      $use_selinux = $selinux
+    }
+  }
+
   include ::mrepo::package
   include ::mrepo::rhn
   include ::mrepo::webservice
   include ::mrepo::selinux
 
-  anchor { 'mrepo::begin':
-    before => Class['mrepo::package'],
-  }
-
-  Class['mrepo::params']     -> Class['mrepo::package']
   Class['mrepo::package']    -> Class['mrepo::webservice']
   Class['mrepo::package']    -> Class['mrepo::rhn']
   Class['mrepo::package']    -> Class['mrepo::selinux']
   Class['mrepo::webservice'] -> Class['mrepo::selinux']
 
-  anchor { 'mrepo::end':
-    require => [
-      Class['mrepo::package'],
-      Class['mrepo::webservice'],
-      Class['mrepo::selinux'],
-      Class['mrepo::rhn'],
-    ],
-  }
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -152,8 +152,6 @@ class mrepo (
   validate_bool($rhn)
   validate_hash($descriptions)
 
-  assert_private('You can no longer refer to the mrepo::params class directly, see https://github.com/voxpupuli/puppet-mrepo#caveats for more details')
-
   if $mailto {
     validate_email_address($mailto)
   }
@@ -192,10 +190,10 @@ class mrepo (
     }
   }
 
-  include ::mrepo::package
-  include ::mrepo::rhn
-  include ::mrepo::webservice
-  include ::mrepo::selinux
+  contain ::mrepo::package
+  contain ::mrepo::rhn
+  contain ::mrepo::webservice
+  contain ::mrepo::selinux
 
   Class['mrepo::package']    -> Class['mrepo::webservice']
   Class['mrepo::package']    -> Class['mrepo::rhn']

--- a/manifests/iso.pp
+++ b/manifests/iso.pp
@@ -3,9 +3,9 @@
 # Downloads isos
 define mrepo::iso($source_url, $repo) {
 
-  include ::mrepo::params
+  include ::mrepo
 
-  $target_file = "${mrepo::params::src_root}/iso/${name}"
+  $target_file = "${mrepo::src_root}/iso/${name}"
 
   staging::file { $name:
     source => "${source_url}/${name}",

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -2,7 +2,7 @@
 #
 # == Parameters
 #
-# Optional parameters can be found in the mrepo::params class
+# None
 #
 # == Examples
 #
@@ -18,13 +18,12 @@
 #
 class mrepo::package {
 
-  include ::mrepo::params
+  $user   = $mrepo::user
+  $group  = $mrepo::group
+  $source = $mrepo::source
+  $proto  = $mrepo::git_proto
+  $ensure = $mrepo::ensure_src
 
-  $user   = $mrepo::params::user
-  $group  = $mrepo::params::group
-  $source = $mrepo::params::source
-  $proto  = $mrepo::params::git_proto
-  $ensure = $mrepo::params::ensure_src
   case $source {
     'git': {
       vcsrepo { '/usr/src/mrepo':
@@ -54,15 +53,15 @@ class mrepo::package {
 
   # mrepo.conf template params
   #
-  $src_root            = $mrepo::params::src_root
-  $www_root            = $mrepo::params::www_root
-  $rhn_username        = $mrepo::params::rhn_username
-  $rhn_password        = $mrepo::params::rhn_password
-  $rhnget_cleanup      = $mrepo::params::rhnget_cleanup
-  $rhnget_download_all = $mrepo::params::rhnget_download_all
-  $mailto              = $mrepo::params::mailto
-  $http_proxy          = $mrepo::params::http_proxy
-  $https_proxy         = $mrepo::params::https_proxy
+  $src_root            = $mrepo::src_root
+  $www_root            = $mrepo::www_root
+  $rhn_username        = $mrepo::rhn_username
+  $rhn_password        = $mrepo::rhn_password
+  $rhnget_cleanup      = $mrepo::rhnget_cleanup
+  $rhnget_download_all = $mrepo::rhnget_download_all
+  $mailto              = $mrepo::mailto
+  $http_proxy          = $mrepo::http_proxy
+  $https_proxy         = $mrepo::https_proxy
 
   file { '/etc/mrepo.conf':
     ensure  => present,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,109 +1,13 @@
 # This class provides default options for mrepo that can be overridden as well
 # as validating overridden parameters.
 #
-# Parameters:
-# [*src_root*]
-# The path to store the mrepo mirror data.
-# Default: /var/mrepo
-#
-# [*www_root*]
-# The path of the mrepo html document root.
-# Default: /var/www/mrepo
-#
-# [*www_ip*]
-# Which IP address to use when www_ip_based is set.
-# Default: $::ipaddress
-#
-# [*www_ip_based*]
-# Whether to use IP-based virtual hosts or not.
-# Default: false
-#
-# [*user*]
-# The account to use for mirroring the files.
-# Default: apache
-#
-# [*group*]
-# The group to use for mirroring the files.
-# Default: apache
-#
-# [*source*]
-# The package source.
-# Default: package
-# Values: git, package
-#
-# [*ensure_src*]
-# Ensure value for the package source.
-# Note that with source set to 'git', setting ensure_src to 'latest'
-#  may cause module-removed source files (e.g. httpd mrepo.conf) to be restored
-# Default: latest
-# Values: latest, present, absent
-#
-# [*selinux*]
-# Whether to update the selinux context for the mrepo document root.
-# Default: the selinux fact.
-# Values: true, false
-#
-# [*rhn*]
-# Whether to install RedHat dependencies or not. Defaults to false.
-# Default: false
-# Values: true, false
-#
-# [*rhn_config*]
-# Whether to install RedHat dependencies for RHN on RHEL. Defaults to false.
-# Note: Irrelevant (assumed true) for CentOS servers with rhn=true.
-# Default: false
-# Values: true, false
-#
-# [*rhn_username*]
-# The Redhat Network username. Must be set if the param rhn is true.
-#
-# [*rhn_password*]
-# The Redhat Network password. Must be set if the param rhn is true.
-#
-# [*rhnget_cleanup*]
-# Clean up packages that are not on the sending side?
-# Default: undef
-# Values: undef, true, false
-#
-# [*rhnget_download_all*]
-# Download older versions of packages?
-# Default: undef
-# Values: undef, true, false
-#
-# [*genid_command*]
-# The base command to use to generate a systemid for RHN (mrepo::repo::rhn).
-# Default: /usr/bin/gensystemid 
-#
-# [*mailto*]
-# The email recipient for mrepo updates. Defaults to unset, meaning no email will be sent.
-#
-# [*mailfrom*]
-# The email sender for mrepo updates. Defaults to unset, meaning mrepo will use its default of `mrepo@`_fqdn_.
-#
-# [*smtpserver*]
-# The SMTP server to use for sending update emails.  Defaults to unset, meaning mrepo will use its default of `localhost`.
-#
-# == Examples
-#
-# node default {
-#   class { "mrepo::params":
-#     src_root     => '/srv/mrepo',
-#     www_root     => '/srv/www/mrepo',
-#     user         => 'www-user',
-#     source       => 'package',
-#     rhn          => true,
-#     rhn_username => 'user',
-#     rhn_password => 'pass',
-#   }
-# }
-#
 # == Author
 #
 # Adrien Thebo <adrien@puppetlabs.com>
 #
 # == Copyright
 #
-# Copyright 2011 Puppet Labs, unless otherwise noted
+# Copyright 2011 Puppet Labs unless otherwise noted
 #
 class mrepo::params (
   $src_root            = '/var/mrepo',
@@ -153,29 +57,4 @@ class mrepo::params (
     validate_re($rhn_password, '.+')
   }
 
-  if $rhnget_cleanup != undef {
-    validate_bool($rhnget_cleanup)
-  }
-  if $rhnget_download_all != undef {
-    validate_bool($rhnget_download_all)
-  }
-
-  # Validate selinux usage. If manually set, validate as a bool and use that value.
-  # If undefined and selinux is present and not disabled, use selinux.
-  case $mrepo::params::selinux {
-    undef: {
-      case $::selinux {
-        'enforcing', 'permissive': {
-          $use_selinux = true
-        }
-        'disabled', default: {
-          $use_selinux = false
-        }
-      }
-    }
-    default: {
-      validate_bool($selinux)
-      $use_selinux = $selinux
-    }
-  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,52 +9,35 @@
 #
 # Copyright 2011 Puppet Labs unless otherwise noted
 #
-class mrepo::params (
-  $src_root            = '/var/mrepo',
-  $www_root            = '/var/www/mrepo',
-  $www_servername      = 'mrepo',
-  $www_ip              = $::ipaddress,
-  $www_ip_based        = false,
-  $user                = 'apache',
-  $group               = 'apache',
-  $source              = 'package',
-  $ensure_src          = 'latest',
-  $selinux             = undef,
-  $rhn                 = false,
-  $rhn_config          = false,
-  $rhn_username        = '',
-  $rhn_password        = '',
-  $rhnget_cleanup      = undef,
-  $rhnget_download_all = undef,
-  $genid_command       = '/usr/bin/gensystemid',
-  $mailto              = undef,
-  $mailfrom            = undef,
-  $smtpserver          = undef,
-  $git_proto           = 'git',
-  $descriptions        = {},
-  $http_proxy          = '',
-  $https_proxy         = '',
-  $priority            = '10',
-  $port                = '80',
-  $selinux_context     = 'system_u:object_r:httpd_sys_content_t',
-) {
-  validate_re($source, '^git$|^package$')
-  validate_re($git_proto, '^git$|^https$')
-  validate_re($priority, '^\d+$')
-  validate_re($port, '^\d+$')
-  validate_bool($rhn)
-  validate_hash($descriptions)
+class mrepo::params
+{
 
-  if $mailto {
-    validate_email_address($mailto)
-  }
-  if $mailfrom {
-    validate_email_address($mailfrom)
-  }
-
-  if $rhn {
-    validate_re($rhn_username, '.+')
-    validate_re($rhn_password, '.+')
-  }
+  $src_root            = '/var/mrepo'
+  $www_root            = '/var/www/mrepo'
+  $www_servername      = 'mrepo'
+  $www_ip              = $::ipaddress
+  $www_ip_based        = false
+  $user                = 'apache'
+  $group               = 'apache'
+  $source              = 'package'
+  $ensure_src          = 'latest'
+  $selinux             = undef
+  $rhn                 = false
+  $rhn_config          = false
+  $rhn_username        = ''
+  $rhn_password        = ''
+  $rhnget_cleanup      = undef
+  $rhnget_download_all = undef
+  $genid_command       = '/usr/bin/gensystemid'
+  $mailto              = undef
+  $mailfrom            = undef
+  $smtpserver          = undef
+  $git_proto           = 'git'
+  $descriptions        = {}
+  $http_proxy          = ''
+  $https_proxy         = ''
+  $priority            = '10'
+  $port                = '80'
+  $selinux_context     = 'system_u:object_r:httpd_sys_content_t'
 
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -28,7 +28,7 @@
 # Values: yum,apt,repomd
 #
 # [*update*]
-# The schedule for updating.The 'now' will update the repo on every run of 
+# The schedule for updating.The 'now' will update the repo on every run of
 # puppet. Be warned that this could be a very lengthy process on the first run.
 # Default: nightly
 # Values: now, nightly, weekly, never
@@ -135,7 +135,6 @@ define mrepo::repo (
   $mrepo_logging = undef,
 ) {
   include ::mrepo
-  include ::mrepo::params
 
   validate_re($ensure, "^present$|^absent$")
   validate_re($arch, "^i386$|^i586$|^x86_64$|^ppc$|^s390$|^s390x$|^ia64$")
@@ -147,13 +146,13 @@ define mrepo::repo (
   # This manages the inconsistent behavior.
   $real_name = mrepo_munge($name, $arch)
 
-  $src_root        = $mrepo::params::src_root
-  $www_root        = $mrepo::params::www_root
+  $src_root        = $mrepo::src_root
+  $www_root        = $mrepo::www_root
   $src_root_subdir = "${src_root}/${real_name}"
   $www_root_subdir = "${www_root}/${real_name}"
 
-  $user  = $mrepo::params::user
-  $group = $mrepo::params::group
+  $user  = $mrepo::user
+  $group = $mrepo::group
 
   case $ensure {
     'present': {
@@ -281,7 +280,7 @@ define mrepo::repo (
         before  => File[$src_root_subdir],
         require => Exec["Unmount any mirrored ISOs for ${name}"],
       }
-      file { "${mrepo::params::src_root}/${name}":
+      file { "${mrepo::src_root}/${name}":
         ensure  => absent,
         backup  => false,
         recurse => false,

--- a/manifests/repo/ncc.pp
+++ b/manifests/repo/ncc.pp
@@ -36,16 +36,16 @@ define mrepo::repo::ncc (
   $repotitle   = $name,
   $typerelease = $release,
 ) {
-  include ::mrepo::params
+  include ::mrepo
 
   # This Class needs testing... no SLES here....
 
   if $ensure == 'present' {
-    $user  = $mrepo::params::user
-    $group = $mrepo::params::group
+    $user  = $mrepo::user
+    $group = $mrepo::group
 
     $real_name = mrepo_munge($name, $arch)
-    $src_root_subdir = "${mrepo::params::src_root}/${real_name}"
+    $src_root_subdir = "${mrepo::src_root}/${real_name}"
 
     file { "${src_root_subdir}/deviceid":
       ensure  => present,

--- a/manifests/repo/rhn.pp
+++ b/manifests/repo/rhn.pp
@@ -37,14 +37,14 @@ define mrepo::repo::rhn (
 ) {
   include ::mrepo::params
 
-  $http_proxy    = $mrepo::params::http_proxy
-  $https_proxy   = $mrepo::params::https_proxy
-  $rhn_username  = $mrepo::params::rhn_username
-  $rhn_password  = $mrepo::params::rhn_password
-  $src_root      = $mrepo::params::src_root
-  $user          = $mrepo::params::user
-  $group         = $mrepo::params::group
-  $genid_command = $mrepo::params::genid_command
+  $http_proxy    = $mrepo::http_proxy
+  $https_proxy   = $mrepo::https_proxy
+  $rhn_username  = $mrepo::rhn_username
+  $rhn_password  = $mrepo::rhn_password
+  $src_root      = $mrepo::src_root
+  $user          = $mrepo::user
+  $group         = $mrepo::group
+  $genid_command = $mrepo::genid_command
 
   $sysid_command = "${genid_command}\s-r\s${typerelease}\s-u\s\'${rhn_username}\'\s-p\s\'${rhn_password}\'\s-a\s${arch}\s\'${src_root}/${name}\'"
 

--- a/manifests/rhn.pp
+++ b/manifests/rhn.pp
@@ -4,7 +4,7 @@
 #
 # == Parameters
 #
-# Optional parameters can be found in the mrepo::params class
+# Optional parameters can be found in the mrepo class
 #
 # == Examples
 #
@@ -20,10 +20,9 @@
 #
 class mrepo::rhn {
 
-  include ::mrepo::params
-  $group        = $mrepo::params::group
-  $rhn          = $mrepo::params::rhn
-  $rhn_config   = $mrepo::params::rhn_config
+  $group        = $mrepo::group
+  $rhn          = $mrepo::rhn
+  $rhn_config   = $mrepo::rhn_config
 
   if $rhn == true {
 
@@ -34,13 +33,13 @@ class mrepo::rhn {
     # CentOS does not have redhat network specific configuration files by default
     if $::operatingsystem == 'CentOS' or $rhn_config == true {
 
-      file {
-        '/etc/sysconfig/rhn':
-          ensure => directory,
-          owner  => 'root',
-          group  => 'root',
-          mode   => '0755',
+      file { '/etc/sysconfig/rhn':
+        ensure => 'file',
+        owner  => 'root',
+        group  => 'root',
+        mode   => '0755',
       }
+
       exec { 'Generate rhnuuid':
         command   => 'printf "rhnuuid=%s\n" `/usr/bin/uuidgen` >> /etc/sysconfig/rhn/up2date-uuid',
         path      => [ '/usr/bin', '/bin' ],
@@ -52,7 +51,7 @@ class mrepo::rhn {
       }
 
       file { '/etc/sysconfig/rhn/up2date-uuid':
-        ensure  => present,
+        ensure  => 'file',
         replace => false,
         owner   => 'root',
         group   => $group,
@@ -61,7 +60,7 @@ class mrepo::rhn {
       }
 
       file { '/etc/sysconfig/rhn/sources':
-        ensure  => present,
+        ensure  => 'file',
         owner   => 'root',
         group   => 'root',
         mode    => '0644',
@@ -69,7 +68,7 @@ class mrepo::rhn {
       }
 
       file { '/usr/share/mrepo/rhn/RHNS-CA-CERT':
-        ensure => present,
+        ensure => 'file',
         owner  => 'root',
         group  => 'root',
         mode   => '0644',

--- a/manifests/selinux.pp
+++ b/manifests/selinux.pp
@@ -19,12 +19,12 @@
 # Copyright 2011 Puppet Labs, unless otherwise noted
 #
 class mrepo::selinux {
-  include ::mrepo::params
-  $src_root = $mrepo::params::src_root
-  $www_root = $mrepo::params::www_root
-  $context  = $mrepo::params::selinux_context
 
-  if $mrepo::params::use_selinux {
+  $src_root = $mrepo::src_root
+  $www_root = $mrepo::www_root
+  $context  = $mrepo::selinux_context
+
+  if $mrepo::use_selinux {
     exec { "Apply httpd context to mrepo ${src_root}":
       command   => "chcon -hR ${context} ${src_root}",
       path      => [ '/usr/bin', '/bin' ],

--- a/manifests/webservice.pp
+++ b/manifests/webservice.pp
@@ -15,16 +15,16 @@
 class mrepo::webservice(
   $ensure = 'present'
 ){
-  include ::mrepo::params
+  include ::mrepo
 
-  $user       = $mrepo::params::user
-  $group      = $mrepo::params::group
-  $docroot    = $mrepo::params::www_root
-  $servername = $mrepo::params::www_servername
-  $priority   = $mrepo::params::priority
-  $port       = $mrepo::params::port
-  $ip_based   = $mrepo::params::www_ip_based
-  $ip         = $mrepo::params::www_ip
+  $user       = $mrepo::user
+  $group      = $mrepo::group
+  $docroot    = $mrepo::www_root
+  $servername = $mrepo::www_servername
+  $priority   = $mrepo::priority
+  $port       = $mrepo::port
+  $ip_based   = $mrepo::www_ip_based
+  $ip         = $mrepo::www_ip
 
   validate_re($ensure, ['^present$','^absent$'])
   case $ensure {

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -8,6 +8,9 @@ describe 'mrepo::package', type: :class do
       end
 
       context 'with default parameters' do
+        let :pre_condition do
+          'class { "mrepo": }'
+        end
         it { is_expected.to compile.with_all_deps }
         describe '/etc/mrepo.conf' do
           it { is_expected.to contain_file('/etc/mrepo.conf') }
@@ -25,7 +28,7 @@ describe 'mrepo::package', type: :class do
       describe 'rhnget_cleanup parameter' do
         context 'with rhnget_cleanup = true' do
           let(:pre_condition) do
-            'class { "mrepo::params": rhnget_cleanup => true }'
+            'class { "mrepo": rhnget_cleanup => true }'
           end
           it do
             content = catalogue.resource('file', '/etc/mrepo.conf').send(:parameters)[:content]
@@ -34,7 +37,7 @@ describe 'mrepo::package', type: :class do
         end
         context 'with rhnget_cleanup = false' do
           let(:pre_condition) do
-            'class { "mrepo::params": rhnget_cleanup => false }'
+            'class { "mrepo": rhnget_cleanup => false }'
           end
           it do
             content = catalogue.resource('file', '/etc/mrepo.conf').send(:parameters)[:content]
@@ -46,7 +49,7 @@ describe 'mrepo::package', type: :class do
       describe 'rhnget_download_all parameter' do
         context 'with rhnget_download_all = true' do
           let(:pre_condition) do
-            'class { "mrepo::params": rhnget_download_all => true }'
+            'class { "mrepo": rhnget_download_all => true }'
           end
           it do
             content = catalogue.resource('file', '/etc/mrepo.conf').send(:parameters)[:content]
@@ -55,7 +58,7 @@ describe 'mrepo::package', type: :class do
         end
         context 'with rhnget_download_all = false' do
           let(:pre_condition) do
-            'class { "mrepo::params": rhnget_download_all => false }'
+            'class { "mrepo": rhnget_download_all => false }'
           end
           it do
             content = catalogue.resource('file', '/etc/mrepo.conf').send(:parameters)[:content]

--- a/templates/apache.conf.erb
+++ b/templates/apache.conf.erb
@@ -14,12 +14,12 @@
 
     #AuthUserFile /var/mrepo/auth/.htpasswd
     #Require user bert dag dries thias
-    
+
     HeaderName HEADER.shtml
     ReadmeName README.shtml
 
-<% scope.lookupvar('mrepo::params::descriptions').keys.sort.each do |key| -%>
-    AddDescription "<%= scope.lookupvar('mrepo::params::descriptions')[key] %>" <%= key %>
+<% scope.lookupvar('mrepo::descriptions').keys.sort.each do |key| -%>
+    AddDescription "<%= scope.lookupvar('mrepo::descriptions')[key] %>" <%= key %>
 <% end -%>
 
     AddDescription "CDROM ISO file" .iso


### PR DESCRIPTION
* Inherit from params in the base class ()
* Changes params to fail if directly referenced
* Requires major version bump: breaking behaviour
* Closes https://github.com/voxpupuli/puppet-mrepo/issues/42