### PR TITLE
Refactors UUID exec to use fqdn_uuid function

### DIFF
--- a/manifests/rhn.pp
+++ b/manifests/rhn.pp
@@ -40,15 +40,8 @@ class mrepo::rhn {
         mode   => '0755',
       }
 
-      exec { 'Generate rhnuuid':
-        command   => 'printf "rhnuuid=%s\n" `/usr/bin/uuidgen` >> /etc/sysconfig/rhn/up2date-uuid',
-        path      => [ '/usr/bin', '/bin' ],
-        user      => 'root',
-        group     => $group,
-        creates   => '/etc/sysconfig/rhn/up2date-uuid',
-        logoutput => on_failure,
-        require   => File['/etc/sysconfig/rhn'],
-      }
+      # Generate UUID using the fqdn_uuid function from stdlib
+      $rhnuuid_setting = fqdn_uuid($::fqdn)
 
       file { '/etc/sysconfig/rhn/up2date-uuid':
         ensure  => 'file',
@@ -56,7 +49,7 @@ class mrepo::rhn {
         owner   => 'root',
         group   => $group,
         mode    => '0640',
-        require => Exec['Generate rhnuuid'],
+        content => "rhnuuid=${rhnuuid_setting}",
       }
 
       file { '/etc/sysconfig/rhn/sources':

--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.15.0 < 5.0.0"
     },
     {
       "name": "puppet/staging",

--- a/spec/classes/rhn_spec.rb
+++ b/spec/classes/rhn_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe 'mrepo::rhn', type: :class do
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge(
+          fqdn: 'mrepo.example.com', # gives uuid 51188cb3-b227-598a-a1d4-f508c78f9e77
+        )
+      end
+
+      context 'with default parameters' do
+        let :pre_condition do
+          'class {"mrepo":
+            rhn          => true,
+            rhn_username => "bob",
+            rhn_password => "hunter2",
+          }'
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it { is_expected.to contain_package('pyOpenSSL') }
+
+        if facts[:operatingsystem] == 'CentOS'
+          it { is_expected.to contain_file('/etc/sysconfig/rhn/up2date-uuid').with_content(%r{rhnuuid=51188cb3-b227-598a-a1d4-f508c78f9e77}) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Rather than exec-ing the file and putting the content in
* Much more idempotent and state based way of generating the file

Blocked on https://github.com/puppetlabs/puppetlabs-stdlib/pull/700 being released (already merged)