### PR TITLE
Set min version_requirement for Puppet + deps

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,17 +38,20 @@
     }
   ],
   "requirements": [
-
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.8.7 <5.0.0"
+    }
   ],
   "description": "Puppet module to configure and manage mrepo mirrors. Mirrors can be generated from distribution ISOs, existing RPM mirrors, the Redhat Network, or Yast Online Update.",
   "dependencies": [
     {
       "name": "puppetlabs/apache",
-      "version_requirement": ">= 0.6.0 < 2.0.0"
+      "version_requirement": ">= 1.6.0 < 2.0.0"
     },
     {
       "name": "puppetlabs/vcsrepo",
-      "version_requirement": ">= 0.0.3 < 2.0.0"
+      "version_requirement": ">= 1.3.1 < 2.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
@@ -56,7 +59,7 @@
     },
     {
       "name": "puppet/staging",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.1 < 3.0.0"
     }
   ]
 }


### PR DESCRIPTION
We currently only run automated tests against Puppet 3 latest and
therefore cannot guarantee that this module works as is expected with
earlier Puppet versions

Bump dependencies to the minimum version that should work under
Puppet 4, based on the metadata