### PR TITLE
Allow users to set apache vhost state

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,10 @@
 # Whether to use IP-based virtual hosts or not.
 # Default: false
 #
+# [*www_ensure*]
+# Ensure apache vhost for mrepo has the given state.
+# Default: present
+#
 # [*user*]
 # The account to use for mirroring the files.
 # Default: apache
@@ -121,6 +125,7 @@ class mrepo (
   $www_servername                        = $::mrepo::params::www_servername,
   $www_ip                                = $::mrepo::params::www_ip,
   $www_ip_based                          = $::mrepo::params::www_ip_based,
+  Enum['present', 'absent'] $www_ensure  = $::mrepo::params::www_ensure,
   $user                                  = $::mrepo::params::user,
   $group                                 = $::mrepo::params::group,
   Enum['git', 'package'] $source         = $::mrepo::params::source,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,7 @@ class mrepo::params
   $www_servername      = 'mrepo'
   $www_ip              = $::ipaddress
   $www_ip_based        = false
-  $www_ensure          = present,
+  $www_ensure          = 'present'
   $user                = 'apache'
   $group               = 'apache'
   $source              = 'package'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class mrepo::params
   $www_servername      = 'mrepo'
   $www_ip              = $::ipaddress
   $www_ip_based        = false
+  $www_ensure          = present,
   $user                = 'apache'
   $group               = 'apache'
   $source              = 'package'

--- a/manifests/webservice.pp
+++ b/manifests/webservice.pp
@@ -12,9 +12,8 @@
 #
 # Copyright 2011 Puppet Labs, unless otherwise noted
 #
-class mrepo::webservice(
-  Enum['present', 'absent'] $ensure = 'present'
-){
+class mrepo::webservice {
+
   include ::mrepo
 
   $user       = $mrepo::user
@@ -25,6 +24,7 @@ class mrepo::webservice(
   $port       = $mrepo::port
   $ip_based   = $mrepo::www_ip_based
   $ip         = $mrepo::www_ip
+  $ensure     = $mrepo::www_ensure
 
   case $ensure {
     'present': {


### PR DESCRIPTION
This PR allows users to set the state of the apache vhost for mrepo when using this module. Currently the vhost is always present.
Some users may already include the apache module or like to configure the mrepo webservice by their own.