### PR TITLE
Manage iso directory within mrepo::iso (requires puppet/archive, drop puppet/staging)

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,9 @@
 fixtures:
   repositories:
-    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-    concat: 'https://github.com/puppetlabs/puppetlabs-concat.git'
-    apache: 'https://github.com/puppetlabs/puppetlabs-apache.git'
+    stdlib:  'https://github.com/puppetlabs/puppetlabs-stdlib.git'
+    concat:  'https://github.com/puppetlabs/puppetlabs-concat.git'
+    apache:  'https://github.com/puppetlabs/puppetlabs-apache.git'
+    archive: 'https://github.com/voxpupuli/puppet-archive.git'
     cron_core:
       repo: https://github.com/puppetlabs/puppetlabs-cron_core.git
       puppet_version: ">= 6.0.0"

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ Mirror multiple rhel channels
       }
     }
 
+Fetch and place an ISO file for the above rhel6server-x86_64 repo
+
+    mrepo::iso { 'rhel-server-6.0-$arch-dvd.iso':
+      source_url => 'http://some.domain.tld/path/to/isodir',
+      repo       => 'rhel6server-x86_64',
+    }
+
 ## Usage ##
 
 If you need to customize the mrepo default settings, include the mrepo
@@ -146,6 +153,7 @@ Is equivalent to this:
       repotitle => 'CentOS 5.6 64 bit',
       arch      => 'x86_64',
       release   => '5.6',
+      urls      => {
         addons      => 'rsync://mirrors.kernel.org/centos/5.6/addons/x86_64/',
         centosplus  => 'rsync://mirrors.kernel.org/centos/5.6/centosplus/x86_64/',
         updates     => 'rsync://mirrors.kernel.org/centos/5.6/updates/x86_64/',

--- a/examples/iso.pp
+++ b/examples/iso.pp
@@ -1,0 +1,4 @@
+mrepo::iso { 'centos5-i386':
+  source_url => 'http://isoredirect.centos.org/centos/7/isos/x86_64/CentOS-7-x86_64-Minimal-1804.iso',
+  repo       => 'centos7-x86_64',
+}

--- a/manifests/iso.pp
+++ b/manifests/iso.pp
@@ -1,6 +1,12 @@
-# = mrepo::iso
+# Class: mrepo::iso
 #
-# Downloads isos
+# This define downloads iso files
+#
+# @param title Specifies the filename of the ISO file
+# @param source_url Specifies the URL portion to the path where the above ISO
+#  file is actually found. This parameter gets concatenated with the filename
+#  from title param, which then forms the whole URL to the ISO file.
+# @param repo Title of the mrepo::repo resources the ISO file belongs to
 define mrepo::iso($source_url, $repo) {
 
   include ::mrepo
@@ -8,15 +14,14 @@ define mrepo::iso($source_url, $repo) {
   $target_file = "${mrepo::src_root}/iso/${name}"
 
   file { "${mrepo::src_root}/iso":
-    ensure  => directory,
-    owner   => $mrepo::user,
-    group   => $mrepo::group,
-    mode    => "0644",
+    ensure => directory,
+    owner  => $mrepo::user,
+    group  => $mrepo::group,
+    mode   => '0644',
   }
 
-  -> staging::file { $name:
+  -> archive { $target_file:
     source => "${source_url}/${name}",
-    target => $target_file,
     before => Mrepo::Repo[$repo],
   }
 }

--- a/manifests/iso.pp
+++ b/manifests/iso.pp
@@ -7,7 +7,14 @@ define mrepo::iso($source_url, $repo) {
 
   $target_file = "${mrepo::src_root}/iso/${name}"
 
-  staging::file { $name:
+  file { "${mrepo::src_root}/iso":
+    ensure  => directory,
+    owner   => $mrepo::user,
+    group   => $mrepo::group,
+    mode    => "0644",
+  }
+
+  -> staging::file { $name:
     source => "${source_url}/${name}",
     target => $target_file,
     before => Mrepo::Repo[$repo],

--- a/metadata.json
+++ b/metadata.json
@@ -58,8 +58,8 @@
       "version_requirement": ">= 4.15.0 < 6.0.0"
     },
     {
-      "name": "puppet/staging",
-      "version_requirement": ">= 2.0.1 < 4.0.0"
+      "name": "puppet/archive",
+      "version_requirement": ">= 3.2.1 < 4.0.0"
     }
   ]
 }

--- a/spec/defines/iso_spec.rb
+++ b/spec/defines/iso_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+
+describe 'mrepo::iso' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:title) { 'CentOS-7-x86_64-Minimal-1804.iso' }
+      let(:params) do
+        {
+          'source_url' => 'http://example.com/isos',
+          'repo'       => 'centos7-x86_64'
+        }
+      end
+      let(:pre_condition) do
+        'mrepo::repo { \'centos7-x86_64\': ensure => present, release => \'7\', arch => \'x86_64\' }'
+      end
+
+      it { is_expected.to compile }
+      it {
+        is_expected.to contain_mrepo__iso('CentOS-7-x86_64-Minimal-1804.iso').
+          with('source_url' => 'http://example.com/isos').
+          with('repo' => 'centos7-x86_64')
+      }
+      it {
+        is_expected.to contain_file('/var/mrepo/iso').
+          with_ensure('directory').
+          with_owner('apache').
+          with_group('apache').
+          with_mode('0644')
+      }
+      it {
+        is_expected.to contain_archive('/var/mrepo/iso/CentOS-7-x86_64-Minimal-1804.iso').
+          with('source' => 'http://example.com/isos/CentOS-7-x86_64-Minimal-1804.iso').
+          that_requires('File[/var/mrepo/iso]')
+      }
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
Previsouly the directory, where iso file are downloaded to, was not
managed by the define mrepo::iso though blindly used, which is not expected behaviour. This
change adds a file resource for the download directory.

#### This Pull Request (PR) fixes the following issues
n/a