### PR TITLE
Remove SymLinksIfOwnerMatch from template

### DIFF
--- a/templates/apache.conf.erb
+++ b/templates/apache.conf.erb
@@ -2,7 +2,7 @@
   Alias /mrepo <%= @docroot %>
 
   <Directory <%= @docroot %>>
-    Options Indexes FollowSymlinks SymLinksifOwnerMatch IncludesNOEXEC
+    Options Indexes FollowSymlinks IncludesNOEXEC
     IndexOptions NameWidth=* DescriptionWidth=*
 
     ### Authentication options


### PR DESCRIPTION
#### Pull Request (PR) description
SymLinksIfOwnerMatch is problematic if the symlink is symlinked again. Chances
are high that the owner/group is different and there's no sense in forcing the
owner/group to be apache (on el7) all the way down.

I hit this in an environemnt where the repo is symlinked to a directory on a nfs share where the user that build rpms is owner whereas mrepo is generating symlinks owned by user apache (on CentOS7/Apache 2.4). I always ran into a 403 Forbidden. Removing the directive fixes the issue.

#### This Pull Request (PR) fixes the following issues
n/a
