### PR TITLE
Add datatypes & multiple enhancements

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@
 #
 # [*www_ip*]
 # Which IP address to use when www_ip_based is set.
-# Default: $::ipaddress
+# Default: $facts['networking']['ip']
 #
 # [*www_ip_based*]
 # Whether to use IP-based virtual hosts or not.
@@ -116,36 +116,37 @@
 # Copyright 2011 Puppet Labs, unless otherwise noted
 #
 class mrepo (
-  $src_root                              = $mrepo::params::src_root,
-  $www_root                              = $mrepo::params::www_root,
-  $www_servername                        = $mrepo::params::www_servername,
-  $www_ip                                = $mrepo::params::www_ip,
-  $www_ip_based                          = $mrepo::params::www_ip_based,
-  $user                                  = $mrepo::params::user,
-  $group                                 = $mrepo::params::group,
-  Enum['git', 'package'] $source         = $mrepo::params::source,
-  $ensure_src                            = $mrepo::params::ensure_src,
-  Optional[Boolean] $selinux             = $mrepo::params::selinux,
-  Boolean $rhn                           = $mrepo::params::rhn,
-  $rhn_config                            = $mrepo::params::rhn_config,
-  Optional[String] $rhn_username         = $mrepo::params::rhn_username,
-  Optional[String] $rhn_password         = $mrepo::params::rhn_password,
-  Optional[Boolean] $rhnget_cleanup      = $mrepo::params::rhnget_cleanup,
-  Optional[Boolean] $rhnget_download_all = $mrepo::params::rhnget_download_all,
-  $genid_command                         = $mrepo::params::genid_command,
-  Optional[String] $mailto               = $mrepo::params::mailto,
-  Optional[String] $mailfrom             = $mrepo::params::mailfrom,
-  $smtpserver                            = $mrepo::params::smtpserver,
-  Enum['git', 'https'] $git_proto        = $mrepo::params::git_proto,
-  Hash $descriptions                     = $mrepo::params::descriptions,
-  $http_proxy                            = $mrepo::params::http_proxy,
-  $https_proxy                           = $mrepo::params::https_proxy,
-  Integer $priority                      = $mrepo::params::priority,
-  Integer $port                          = $mrepo::params::port,
-  $selinux_context                       = $mrepo::params::selinux_context,
-  $service_enable                        = $mrepo::params::service_enable,
-  $service_manage                        = $mrepo::params::service_manage,
-) inherits ::mrepo::params {
+  Stdlib::Absolutepath $src_root                  = $mrepo::params::src_root,
+  Stdlib::Absolutepath $www_root                  = $mrepo::params::www_root,
+  String[1] $www_servername                       = $mrepo::params::www_servername,
+  Optional[Stdlib::IP::Address] $www_ip           = $mrepo::params::www_ip,
+  Boolean $www_ip_based                           = $mrepo::params::www_ip_based,
+  String[1] $user                                 = $mrepo::params::user,
+  String[1] $group                                = $mrepo::params::group,
+  Enum['git', 'package'] $source                  = $mrepo::params::source,
+  Enum['latest', 'present', 'absent'] $ensure_src = $mrepo::params::ensure_src,
+  Optional[Boolean] $selinux                      = $mrepo::params::selinux,
+  Boolean $rhn                                    = $mrepo::params::rhn,
+  Boolean $rhn_config                             = $mrepo::params::rhn_config,
+  Optional[String[1]] $rhn_username               = $mrepo::params::rhn_username,
+  Optional[String[1]] $rhn_password               = $mrepo::params::rhn_password,
+  Optional[Boolean] $rhnget_cleanup               = $mrepo::params::rhnget_cleanup,
+  Optional[Boolean] $rhnget_download_all          = $mrepo::params::rhnget_download_all,
+  Stdlib::Absolutepath $genid_command             = $mrepo::params::genid_command,
+  Optional[String[1]] $mailto                     = $mrepo::params::mailto,
+  Optional[String[1]] $mailfrom                   = $mrepo::params::mailfrom,
+  Optional[Stdlib::Host] $smtpserver              = $mrepo::params::smtpserver,
+  Enum['git', 'https'] $git_proto                 = $mrepo::params::git_proto,
+  Hash $descriptions                              = $mrepo::params::descriptions,
+  Optional[Stdlib::HTTPUrl] $http_proxy           = $mrepo::params::http_proxy,
+  Optional[Stdlib::HTTPUrl] $https_proxy          = $mrepo::params::https_proxy,
+  Integer $priority                               = $mrepo::params::priority,
+  Integer $port                                   = $mrepo::params::port,
+  Optional[String[1]] $createrepo_options         = $mrepo::params::createrepo_options,
+  String[1] $selinux_context                      = $mrepo::params::selinux_context,
+  Boolean $service_enable                         = $mrepo::params::service_enable,
+  Boolean $service_manage                         = $mrepo::params::service_manage,
+) inherits mrepo::params {
 
   if $rhn {
     assert_type(String[1], $rhn_username)
@@ -156,7 +157,7 @@ class mrepo (
   # If undefined and selinux is present and not disabled, use selinux.
   case $mrepo::selinux {
     undef: {
-      case $::selinux {
+      case $selinux {
         'enforcing', 'permissive': {
           $use_selinux = true
         }

--- a/manifests/iso.pp
+++ b/manifests/iso.pp
@@ -8,20 +8,20 @@
 #  from title param, which then forms the whole URL to the ISO file.
 # @param repo Title of the mrepo::repo resources the ISO file belongs to
 define mrepo::iso($source_url, $repo) {
-
   include mrepo
 
   $target_file = "${mrepo::src_root}/iso/${name}"
 
-  file { "${mrepo::src_root}/iso":
-    ensure => directory,
-    owner  => $mrepo::user,
-    group  => $mrepo::group,
-    mode   => '0644',
-  }
+  ensure_resource('file', "${mrepo::src_root}/iso", {
+    'ensure' => 'directory',
+    'owner'  => $mrepo::user,
+    'group'  => $mrepo::group,
+    'mode'   => '0644',
+  })
 
-  -> archive { $target_file:
-    source => "${source_url}/${name}",
-    before => Mrepo::Repo[$repo],
+  archive { $target_file:
+    source  => "${source_url}/${name}",
+    before  => Mrepo::Repo[$repo],
+    require => File["${mrepo::src_root}/iso"],
   }
 }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -62,6 +62,7 @@ class mrepo::package {
   $mailto              = $mrepo::mailto
   $http_proxy          = $mrepo::http_proxy
   $https_proxy         = $mrepo::https_proxy
+  $createrepo_options  = $mrepo::createrepo_options
 
   file { '/etc/mrepo.conf':
     ensure  => present,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,13 +9,11 @@
 #
 # Copyright 2011 Puppet Labs unless otherwise noted
 #
-class mrepo::params
-{
-
+class mrepo::params {
   $src_root            = '/var/mrepo'
   $www_root            = '/var/www/mrepo'
   $www_servername      = 'mrepo'
-  $www_ip              = $::ipaddress
+  $www_ip              = $facts['networking']['ip']
   $www_ip_based        = false
   $user                = 'apache'
   $group               = 'apache'
@@ -24,8 +22,8 @@ class mrepo::params
   $selinux             = undef
   $rhn                 = false
   $rhn_config          = false
-  $rhn_username        = ''
-  $rhn_password        = ''
+  $rhn_username        = undef
+  $rhn_password        = undef
   $rhnget_cleanup      = undef
   $rhnget_download_all = undef
   $genid_command       = '/usr/bin/gensystemid'
@@ -34,12 +32,12 @@ class mrepo::params
   $smtpserver          = undef
   $git_proto           = 'git'
   $descriptions        = {}
-  $http_proxy          = ''
-  $https_proxy         = ''
+  $http_proxy          = undef
+  $https_proxy         = undef
   $priority            = 10
   $port                = 80
+  $createrepo_options  = undef
   $selinux_context     = 'system_u:object_r:httpd_sys_content_t'
   $service_enable      = true
   $service_manage      = false
-
 }

--- a/manifests/repo/ncc.pp
+++ b/manifests/repo/ncc.pp
@@ -23,18 +23,18 @@
 # Copyright 2012 Puppet Labs, unless otherwise noted
 #
 define mrepo::repo::ncc (
-  $ensure,
-  $release,
-  $arch,
-  $ncc_username,
-  $ncc_password,
-  $urls        = {},
-  $metadata    = 'repomd',
-  $update      = 'nightly',
-  $hour        = '0',
-  $iso         = '',
-  $repotitle   = $name,
-  $typerelease = $release,
+  Enum['present', 'absent'] $ensure,
+  String[1] $release,
+  Mrepo::Arch $arch,
+  String[1] $ncc_username,
+  String[1] $ncc_password,
+  Hash[String, String] $urls        = {},
+  String[1] $metadata               = 'repomd',
+  Mrepo::Update $update             = 'nightly',
+  Variant[String[1], Integer] $hour = '0',
+  Optional[String[1]] $iso          = undef,
+  String[1] $repotitle              = $name,
+  Optional[String[1]] $typerelease  = $release,
 ) {
   include mrepo
 

--- a/manifests/repo/rhn.pp
+++ b/manifests/repo/rhn.pp
@@ -24,16 +24,16 @@
 # Copyright 2012 Puppet Labs, unless otherwise noted
 #
 define mrepo::repo::rhn (
-  $ensure,
-  $release,
-  $arch,
-  $urls        = {},
-  $metadata    = 'repomd',
-  $update      = 'nightly',
-  $hour        = '0',
-  $iso         = '',
-  $typerelease = $release,
-  $repotitle   = $name,
+  Enum['present', 'absent'] $ensure,
+  String[1] $release,
+  Mrepo::Arch $arch,
+  Hash[String, String] $urls        = {},
+  String[1] $metadata               = 'repomd',
+  Mrepo::Update $update             = 'nightly',
+  Variant[String[1], Integer] $hour = '0',
+  Optional[String[1]] $iso          = undef,
+  String[1] $repotitle              = $name,
+  Optional[String[1]] $typerelease  = $release,
 ) {
   include mrepo::params
 

--- a/manifests/rhn.pp
+++ b/manifests/rhn.pp
@@ -31,7 +31,7 @@ class mrepo::rhn {
     }
 
     # CentOS does not have redhat network specific configuration files by default
-    if $::operatingsystem == 'CentOS' or $rhn_config == true {
+    if $facts['os']['name'] == 'CentOS' or $rhn_config == true {
 
       file { '/etc/sysconfig/rhn':
         ensure => 'file',
@@ -41,7 +41,7 @@ class mrepo::rhn {
       }
 
       # Generate UUID using the fqdn_uuid function from stdlib
-      $rhnuuid_setting = fqdn_uuid($::fqdn)
+      $rhnuuid_setting = fqdn_uuid($facts['networking']['fqdn'])
 
       file { '/etc/sysconfig/rhn/up2date-uuid':
         ensure  => 'file',

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -71,6 +71,16 @@ describe 'mrepo::package', type: :class do
           end
         end
       end
+      describe 'with createrepo_options' do
+        let(:pre_condition) do
+          'class { "mrepo": createrepo_options => "--some-opt --another-opt -q -p" }'
+        end
+
+        it do
+          content = catalogue.resource('file', '/etc/mrepo.conf').send(:parameters)[:content]
+          expect(content).to match %r{^createrepo-options = --some-opt --another-opt -q -p$}
+        end
+      end
     end
   end
 end

--- a/spec/classes/rhn_spec.rb
+++ b/spec/classes/rhn_spec.rb
@@ -3,10 +3,10 @@ require 'spec_helper'
 describe 'mrepo::rhn', type: :class do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
+      let(:node) { 'mrepo.example.com' } # gives uuid 51188cb3-b227-598a-a1d4-f508c78f9e77
+
       let(:facts) do
-        facts.merge(
-          fqdn: 'mrepo.example.com', # gives uuid 51188cb3-b227-598a-a1d4-f508c78f9e77
-        )
+        facts
       end
 
       context 'with default parameters' do

--- a/templates/mrepo.conf.erb
+++ b/templates/mrepo.conf.erb
@@ -5,16 +5,19 @@ srcdir  = <%= @src_root %>
 wwwdir  = <%= @www_root %>
 confdir = /etc/mrepo.conf.d
 
-<% if not @http_proxy.empty? -%>
+<% if @createrepo_options -%>
+createrepo-options = <%= @createrepo_options %>
+<% end -%>
+<% if @http_proxy -%>
 http_proxy = <%= @http_proxy %>
 <% end -%>
-<% if not @https_proxy.empty? -%>
+<% if @https_proxy -%>
 https_proxy = <%= @https_proxy %>
 <% end -%>
 
-<% if not @rhn_username.empty? and not @rhn_password.empty? -%>
+<% if @rhn_username and @rhn_password -%>
 rhnlogin = <%= @rhn_username %>:<%= @rhn_password %>
-<% elsif not @rhn_username.empty? -%>
+<% elsif @rhn_username -%>
 rhnlogin = <%= @rhn_username %>
 <% end -%>
 <% unless @rhnget_cleanup.nil? -%>

--- a/templates/repo.conf.erb
+++ b/templates/repo.conf.erb
@@ -5,7 +5,7 @@ name = <%= @repotitle %>
 release = <%= @release %>
 arch = <%= @arch %>
 metadata = <%= if @metadata.is_a? Array; then @metadata.join(' '); else @metadata; end %>
-<% unless @iso.empty? -%>
+<% if @iso -%>
 iso = <%= @iso %>
 <% end -%>
 <% @urls.keys.sort.each do |rname| -%>

--- a/types/arch.pp
+++ b/types/arch.pp
@@ -1,1 +1,1 @@
-type Mrepo::Arch = Enum['i386', 'i586', 'x86_64', 'ppc', 's390', 's390x', 'ia64']
+type Mrepo::Arch = Enum['i386', 'i586', 'x86_64', 'ppc', 'ppc64le', 's390', 's390x', 'ia64']


### PR DESCRIPTION
We have had a fork for a couple of years now and I am hoping we can contribute our changes to the Vox Pupuli version of this module so that we no longer need it. This is a combination of the changes below. Attribution for the original work is done via the co-author lines at the end of the commit message

- Allow passing options to createrepo in mrepo.conf
- Add createrepo_options variable to package class
- Add regex validation for ppc64le architecture
  - Modified manifests/repo.pp and added a regex statement for validating ppc64le architecture when used in the $arch param. (I modified the original commit to update the new type used upstream while resolving merge conflicts)
- Additional changes based on work upstream
  - Added a spec test to cover createrepo_options
  - Fixed duplicate resource declaration in iso.pp
  - Fixed passing params through to ncc and rhn repo types
  - Typed all parameters and replaced empty strings with undef
  - Removed .empty? checks from erb due to Puppet type checking doing this
  - Replaced legacy and top-scope facts