### PR TITLE
Fix use of `selinux` fact

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -157,7 +157,7 @@ class mrepo (
   # If undefined and selinux is present and not disabled, use selinux.
   case $mrepo::selinux {
     undef: {
-      case $selinux {
+      case fact('os.selinux.current_mode') {
         'enforcing', 'permissive': {
           $use_selinux = true
         }
@@ -167,8 +167,7 @@ class mrepo (
       }
     }
     default: {
-      assert_type(Boolean, $selinux)
-      $use_selinux = $selinux
+      $use_selinux = $mrepo::selinux
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -55,7 +55,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.15.0 < 7.0.0"
+      "version_requirement": ">= 4.19.0 < 7.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
Before 4d29ce881d653cd53c8c77e82bb840e2a9e7f3d8 the `$::selinux` fact
was being used.  This got accidentally changed to the local variable
`$selinux`.

It was always broken though as the legacy `selinux` fact is a boolean
and would have never been `enforcing` or `permissive`.

For added clarity, I've used `$mrepo::selinux` instead of just
`$selinux` when the intention is to refer to the non-fact class
variable.